### PR TITLE
PP-8263 Update the `pre-commit` and `detect-secrets` setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/Yelp/detect-secrets
+  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
+  hooks:
+    - id: detect-secrets
+      args: ['--baseline', '.secrets.baseline']
+      exclude: package.lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,19 +1,15 @@
 {
-  "exclude": {
-    "files": null,
-    "lines": null
-  },
-  "generated_at": "2021-04-22T15:10:45Z",
+  "version": "1.1.0",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -22,8 +18,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "IbmCloudIamDetector"
@@ -35,8 +31,8 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
@@ -57,43 +53,74 @@
       "name": "TwilioKeyDetector"
     }
   ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
   "results": {
-    "docs/documentation/publishing-on-heroku.md": [
+    ".pre-commit-config.yaml": [
       {
-        "hashed_secret": "88d5f0d556ec8a3f863c0d8ea710db73bc0731f3",
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
         "is_verified": false,
-        "line_number": 55,
-        "type": "Secret Keyword"
-      }
-    ],
-    "docs/documentation/using-notify.md": [
-      {
-        "hashed_secret": "2db6d21d365f544f7ca3bcfb443ac96898a7a069",
-        "is_verified": false,
-        "line_number": 37,
-        "type": "Secret Keyword"
+        "line_number": 3
       }
     ],
     "lib/middleware/authentication/authentication.test.js": [
       {
+        "type": "Secret Keyword",
+        "filename": "lib/middleware/authentication/authentication.test.js",
         "hashed_secret": "354b3a4b7715d3694c88a4fa7db49e41de86568e",
         "is_verified": false,
-        "line_number": 60,
-        "type": "Secret Keyword"
+        "line_number": 60
       }
     ],
     "manifest.yml": [
       {
+        "type": "Secret Keyword",
+        "filename": "manifest.yml",
         "hashed_secret": "b4b7b98f2619ac64d4493f14def6ae2be24a2e74",
         "is_verified": false,
-        "line_number": 10,
-        "type": "Secret Keyword"
+        "line_number": 10
       }
     ]
   },
-  "version": "0.13.1",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "generated_at": "2021-08-17T11:51:34Z"
 }


### PR DESCRIPTION
- Add a local `.pre-commit.yaml`
  - This will run `detect-secrets` when you try to commit a file.
- Update the existing `.secrets.baseline` file
  - To ignore the SHA specified in the `.pre-commit.yaml`